### PR TITLE
use npm replicate instead of github replicate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,10 @@
         "chai": "^4.3.10",
         "lodash-es": "^4.17.21",
         "mocha": "^10.2.0",
-        "replicate": "github:replicate/replicate-javascript#add-method-for-listing-public-models"
+        "replicate": "^0.20.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ansi-colors": {
@@ -836,10 +839,10 @@
       }
     },
     "node_modules/replicate": {
-      "version": "0.19.0",
-      "resolved": "git+ssh://git@github.com/replicate/replicate-javascript.git#b4ea11b07a151be425f524f5bef69048685a775f",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/replicate/-/replicate-0.20.1.tgz",
+      "integrity": "sha512-QVyI1rowGsSfNuDrRmumYPdCHa/fN/RkI3NHpcK0i5hSSiWK69URAyheAC/0MIAiS3oUs4kD56PB9zEI4oHENw==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "git": ">=2.11.0",
         "node": ">=18.0.0",
@@ -1620,9 +1623,10 @@
       }
     },
     "replicate": {
-      "version": "git+ssh://git@github.com/replicate/replicate-javascript.git#b4ea11b07a151be425f524f5bef69048685a775f",
-      "dev": true,
-      "from": "replicate@github:replicate/replicate-javascript#add-method-for-listing-public-models"
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/replicate/-/replicate-0.20.1.tgz",
+      "integrity": "sha512-QVyI1rowGsSfNuDrRmumYPdCHa/fN/RkI3NHpcK0i5hSSiWK69URAyheAC/0MIAiS3oUs4kD56PB9zEI4oHENw==",
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "chai": "^4.3.10",
     "lodash-es": "^4.17.21",
     "mocha": "^10.2.0",
-    "replicate": "github:replicate/replicate-javascript#add-method-for-listing-public-models"
+    "replicate": "^0.20.1"
   },
   "type": "module",
   "main": "index.mjs",


### PR DESCRIPTION
The `replicate.models.list()` method was a WIP but is now part of the released npm package.